### PR TITLE
Add Filtering by Period

### DIFF
--- a/app/src/errors/invalidPeriod.js
+++ b/app/src/errors/invalidPeriod.js
@@ -1,0 +1,11 @@
+'use strict';
+
+class InvalidPeriod extends Error{
+
+    constructor(message){
+        super(message);
+        this.name = 'Invalid Period';
+        this.message = message;
+    }
+}
+module.exports = InvalidPeriod;

--- a/app/src/routes/api/v2/umdLossGainRouter.js
+++ b/app/src/routes/api/v2/umdLossGainRouter.js
@@ -17,7 +17,7 @@ class UMDLossGainRouterV2 {
         logger.info('Obtaining adm2 data');
         const thresh = this.query.thresh || '30';
         const polyname = this.query.polyname || 'gadm28';
-        const period = this.query.period || '2001,2017';
+        const period = this.query.period || '2001-01-01,2017-12-31';
         let data = yield V2DBService.fetchData({ iso: iso.toUpperCase(), adm1: id1, adm2: id2, thresh, polyname, period });
         this.body = V2UMDSerializer.serialize(data);
     }

--- a/app/src/routes/api/v2/umdLossGainRouter.js
+++ b/app/src/routes/api/v2/umdLossGainRouter.js
@@ -17,7 +17,8 @@ class UMDLossGainRouterV2 {
         logger.info('Obtaining adm2 data');
         const thresh = this.query.thresh || '30';
         const polyname = this.query.polyname || 'gadm28';
-        let data = yield V2DBService.fetchData({ iso: iso.toUpperCase(), adm1: id1, adm2: id2, thresh, polyname });
+        const period = this.query.period || '2001,2017';
+        let data = yield V2DBService.fetchData({ iso: iso.toUpperCase(), adm1: id1, adm2: id2, thresh, polyname, period });
         this.body = V2UMDSerializer.serialize(data);
     }
 }

--- a/app/src/routes/api/v2/umdLossGainRouter.js
+++ b/app/src/routes/api/v2/umdLossGainRouter.js
@@ -17,7 +17,7 @@ class UMDLossGainRouterV2 {
         logger.info('Obtaining adm2 data');
         const thresh = this.query.thresh || '30';
         const polyname = this.query.polyname || 'gadm28';
-        const period = this.query.period || '2001-01-01,2017-12-31';
+        const period = this.query.period || null;
         let data = yield V2DBService.fetchData({ iso: iso.toUpperCase(), adm1: id1, adm2: id2, thresh, polyname, period });
         this.body = V2UMDSerializer.serialize(data);
     }

--- a/app/src/routes/api/v2/umdLossGainRouter.js
+++ b/app/src/routes/api/v2/umdLossGainRouter.js
@@ -4,6 +4,7 @@ const Router = require('koa-router');
 const logger = require('logger');
 const V2DBService = require('services/v2DBService');
 const NotFound = require('errors/notFound');
+const InvalidPeriod = require('errors/invalidPeriod');
 const V2UMDSerializer = require('serializers/v2UmdSerializer');
 
 const router = new Router({
@@ -17,9 +18,16 @@ class UMDLossGainRouterV2 {
         logger.info('Obtaining adm2 data');
         const thresh = this.query.thresh || '30';
         const polyname = this.query.polyname || 'gadm28';
-        const period = this.query.period || null;
-        let data = yield V2DBService.fetchData({ iso: iso.toUpperCase(), adm1: id1, adm2: id2, thresh, polyname, period });
-        this.body = V2UMDSerializer.serialize(data);
+        const period = this.query.period.split(',').map(el => el.trim()).join(',') || null;
+        try {
+            let data = yield V2DBService.fetchData({ iso: iso.toUpperCase(), adm1: id1, adm2: id2, thresh, polyname, period });
+            this.body = V2UMDSerializer.serialize(data);
+        } catch (err) {
+            if (err instanceof InvalidPeriod) {
+                this.throw(400, err.message);
+                return;
+            }
+        }
     }
 }
 

--- a/app/src/serializers/v2UmdSerializer.js
+++ b/app/src/serializers/v2UmdSerializer.js
@@ -4,7 +4,7 @@ var logger = require('logger');
 var JSONAPISerializer = require('jsonapi-serializer').Serializer;
 var v2UmdSerializer = new JSONAPISerializer('umd-v2', {
 
-    attributes: ['iso', 'adm1', 'adm2', 'thresh', 'polyname', 'totals', 'years'],
+    attributes: ['iso', 'adm1', 'adm2', 'thresh', 'polyname', 'period', 'totals', 'years'],
     totals:{
         attributes: ['areaHa', 'extent2000', 'extent2000Perc', 'extent2010', 'extent2010Perc', 'gain', 'gainPerc', 'loss', 'lossPerc']
     },

--- a/app/src/services/v2DBService.js
+++ b/app/src/services/v2DBService.js
@@ -166,7 +166,8 @@ class V2DBService {
         if (data.data.length === 0) {
             return [];
         }
-        const periods = params.period && params.period.split(',');        
+        const dates = params.period && params.period.split(',');
+        const periods = [dates[0].slice(0,4), dates[1].slice(0,4)];    
         if (data && Object.keys(data).length > 0) {
             const totals = V2DBService.getTotals(data.data, periods);
             const returnData = Object.assign({

--- a/app/src/services/v2DBService.js
+++ b/app/src/services/v2DBService.js
@@ -35,45 +35,45 @@ var deserializer = function(obj) {
 
 class V2DBService {
     // use this for testing locally
-    static * getData(sql, params) {
-        sql = sql.replace('{location}', getLocationString(params))
-                 .replace('{vars}', getLocationVars(params))
-                 .replace('{threshold}', params.thresh)
-                 .replace('{area_type}', getAreaType(params.polyname))
-                 .replace('{polyname}', params.polyname);
-    
-        logger.debug('Obtaining data with:', sql);
-        let result = yield request.get('https://production-api.globalforestwatch.org/v1/query/499682b1-3174-493f-ba1a-368b4636708e?sql='+sql); // move to env
-        if (result.statusCode !== 200) {
-            console.error('Error obtaining data:');
-            console.error(result);
-            return null;
-        }
-        return JSON.parse(result.body);
-    }
-
-    //Use this one for prod/staging
     // static * getData(sql, params) {
     //     sql = sql.replace('{location}', getLocationString(params))
     //              .replace('{vars}', getLocationVars(params))
     //              .replace('{threshold}', params.thresh)
     //              .replace('{area_type}', getAreaType(params.polyname))
     //              .replace('{polyname}', params.polyname);
-
+    
     //     logger.debug('Obtaining data with:', sql);
-    //     try {
-    //         let result = yield MicroServiceClient.requestToMicroservice({
-    //             uri: `/query/499682b1-3174-493f-ba1a-368b4636708e?sql=${sql}`,
-    //             method: 'GET',
-    //             json: true
-    //         });
-    //         logger.debug(result);
-    //         return result.body;
-    //     } catch (err) {
-    //         logger.error(err);
-    //         throw err;
+    //     let result = yield request.get('https://production-api.globalforestwatch.org/v1/query/499682b1-3174-493f-ba1a-368b4636708e?sql='+sql); // move to env
+    //     if (result.statusCode !== 200) {
+    //         console.error('Error obtaining data:');
+    //         console.error(result);
+    //         return null;
     //     }
+    //     return JSON.parse(result.body);
     // }
+
+    //Use this one for prod/staging
+    static * getData(sql, params) {
+        sql = sql.replace('{location}', getLocationString(params))
+                 .replace('{vars}', getLocationVars(params))
+                 .replace('{threshold}', params.thresh)
+                 .replace('{area_type}', getAreaType(params.polyname))
+                 .replace('{polyname}', params.polyname);
+
+        logger.debug('Obtaining data with:', sql);
+        try {
+            let result = yield MicroServiceClient.requestToMicroservice({
+                uri: `/query/499682b1-3174-493f-ba1a-368b4636708e?sql=${sql}`,
+                method: 'GET',
+                json: true
+            });
+            logger.debug(result);
+            return result.body;
+        } catch (err) {
+            logger.error(err);
+            throw err;
+        }
+    }
 
     static sum (a, b) {
         return a + b;

--- a/app/src/services/v2DBService.js
+++ b/app/src/services/v2DBService.js
@@ -79,10 +79,12 @@ class V2DBService {
         return a + b;
     }
 
-    static getLossTotal (data, start_year, end_year) {
+    static getLossTotal (data, periods) {
         let loss = data.map(obj => {
-            let lossTotal = obj.loss_data
-                .filter(year => year.year >= start_year && year.year <= end_year)
+            const filteredLoss = 
+                periods ? obj.loss_data.filter(year => year.year >= periods[0] && year.year <= periods[1])
+                        : obj.loss_data;
+            let lossTotal = filteredLoss    
                 .map(year => {
                     return year.area_loss;
                 });
@@ -93,8 +95,10 @@ class V2DBService {
 
     static getLossByYear (data, area, periods) {
         let loss = data.map(obj => {
-            let lossTotal = obj.loss_data
-                .filter(year => year.year >= periods[0] && year.year <= periods[1])
+            const filteredLoss = 
+                periods ? obj.loss_data.filter(year => year.year >= periods[0] && year.year <= periods[1])
+                        : obj.loss_data;
+            let lossTotal = filteredLoss
                 .map(year => {
                     let tmp = {
                         year: year.year,
@@ -153,7 +157,7 @@ class V2DBService {
             returnData.gain += d.gain;
             returnData.areaHa += d.area;
         });
-        returnData.loss = V2DBService.getLossTotal(data, periods[0], periods[1]);
+        returnData.loss = V2DBService.getLossTotal(data, periods);
         returnData.extent2000Perc = 100 * returnData.extent2000 / returnData.areaHa;
         returnData.extent2010Perc = 100 * returnData.extent2010 / returnData.areaHa;
         returnData.gainPerc = 100 * returnData.gain / returnData.areaHa;
@@ -167,7 +171,7 @@ class V2DBService {
             return [];
         }
         const dates = params.period && params.period.split(',');
-        const periods = [dates[0].slice(0,4), dates[1].slice(0,4)];    
+        const periods = params.period && [dates[0].slice(0,4), dates[1].slice(0,4)];    
         if (data && Object.keys(data).length > 0) {
             const totals = V2DBService.getTotals(data.data, periods);
             const returnData = Object.assign({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,383 @@
+{
+  "name": "gfw-umd-forest-api",
+  "version": "1.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
+      },
+      "dependencies": {
+        "co": {
+          "version": "4.6.0",
+          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+        }
+      }
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "boom": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "requires": {
+        "hoek": "4.2.1"
+      }
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "combined-stream": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cryptiles": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "requires": {
+        "boom": "5.2.0"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "requires": {
+            "hoek": "4.2.1"
+          }
+        }
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "2.1.18"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "requires": {
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
+      }
+    },
+    "hawk": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "requires": {
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.1",
+        "sntp": "2.1.0"
+      }
+    },
+    "hoek": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.13.1"
+      }
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+    },
+    "mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "requires": {
+        "mime-db": "1.33.0"
+      }
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "qs": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+    },
+    "request": {
+      "version": "2.83.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "requires": {
+        "aws-sign2": "0.7.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.18",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.2.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "sntp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "requires": {
+        "hoek": "4.2.1"
+      }
+    },
+    "sshpk": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+    },
+    "tough-cookie": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "requires": {
+        "punycode": "1.4.1"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
+    },
+    "uuid": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "koa-router": "5.4.0",
     "koa-validate": "0.2.11",
     "lru-cache": "4.0.1",
+    "moment": "2.22.2",
     "mustache": "2.2.1",
     "newrelic": "1.27.1",
     "python-shell": "0.4.0",


### PR DESCRIPTION
## Overview 

Updates the microservice to accept a period range to filter loss data by year by adding `?period=startDate,endDate` to the url.

e.g. `.../api/v2/umd-loss-gain/admin/bra/1/1?period=2010-02-17,2013-12-31`

Filters loss years by the years 2010 - 2013 inclusive, and returns:

Returns:

```json

{
    "data": {
    "type": "umd-v2",
    "id": "undefined",
    "attributes": {
        "iso": "BRA",
        "adm1": "1",
        "adm2": "1",
        "thresh": "30",
        "polyname": "gadm28",
        "period": "2010-02-17,2013-12-31",
        "totals": {
            "areaHa": 158561.89705,
            "extent2000": 122284.800486,
            "extent2000Perc": 77.12117650020257,
            "extent2010": 74653.45274410001,
            "extent2010Perc": 47.08158399527676,
            "gain": 440.822701979,
            "gainPerc": 0.27801300954414887,
            "loss": 6443.98327242,
            "lossPerc": 4.064017517643593
        },
        "years": [
            {
                "year": "2010",
                "loss": 2866.05764415,
                "lossPerc": 1.8075323879647038
            },{
                "year": "2011",
                "loss": 1081.81024862,
                "lossPerc": 0.6822636892890277
            },{
                "year": "2012",
                "loss": 1105.80247636,
                "lossPerc": 0.6973948325121908
            },{
                "year": "2013",
                "loss": 1390.31290329,
                "lossPerc": 0.876826607877671
                }
            ]
        }
    }
}
```

## Notes

- Only takes into account the years passed, currently ignores the days/months
- Filtering by year affects only the data returned in the `years` key, as well as the values for `loss` and `lossPerc` in the `totals` key.
- If no period passed, returns loss data for all years
- Adds 'period' key to indicate filtered dates