### PR TITLE
Update the docker development environment variables

### DIFF
--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -1,17 +1,17 @@
 develop:
-  extends:
-    file: base.yml
-    service: base
+  build: .
   ports:
-    - "35737:35729"
+    - "3603:3603"
   container_name: gfw-umd-forest-api-develop
   environment:
+    PORT: 3603
     NODE_ENV: dev
+    NODE_PATH: app/src
     ENVIRONMENT: dev
     DEBUG: "True"
     CT_URL: http://mymachine:9000
     CT_TOKEN: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Im1pY3Jvc2VydmljZSIsImNyZWF0ZWRBdCI6IjIwMTYtMDktMTQifQ.IRCIRm1nfIQTfda_Wb6Pg-341zhV8soAgzw7dd5HxxQ
-    LOCAL_URL: http://mymachine:3600
+    LOCAL_URL: http://mymachine:3603
     API_GATEWAY_URL: http://mymachine:9000
     EE_PRIVATE_KEY: ${EE_PRIVATE_KEY}
     CARTODB_USER: ${CARTODB_USER}


### PR DESCRIPTION
This PR fixes issues when using docker in a local development environment. Running `./umdForest.sh develop` currently throws an error relating to a missing `base.yml` file. Instead of looking for the `base.yml` file we now set the build location directly in the `docker-compose-develop.yml` file.

Once the build location is fixed, another error is thrown `Cannot find module 'app'`. This is due to the `NODE_PATH` environment variable not being set.

I've also updated the ports to prevent conflicts with another service/api.